### PR TITLE
Fix path to textToImage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/text-to-image');
+module.exports = require('./lib/textToImage');


### PR DESCRIPTION
The path to the lib file specified in `index.js` is incorrect. The file path is currently `./lib/textToImage`. Either the path should be updated or the file name should be changed.